### PR TITLE
provide a flag to trace SMTP exchange

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,52 @@ an Excel spreadsheet to Bob using the SMTP client.
 #+BEGIN_SRC haskell
 >>> :set -XOverloadedStrings
 >>> :module Network.Mail.Mime Network.Mail.Client.Gmail
->>> sendGmail "alice" "password" (Address (Just "Alice") "alice@gmail.com") [Address (Just "Bob") "bob@example.com"] [] [] "Excel Spreadsheet" "Hi Bob,\n\nThe Excel spreadsheet is attached.\n\nRegards,\n\nAlice" ["Spreadsheet.xls"]
+>>> sendGmail "alice" "password" (Address (Just "Alice") "alice@gmail.com") [Address (Just "Bob") "bob@example.com"] [] [] "Excel Spreadsheet" "Hi Bob,\n\nThe Excel spreadsheet is attached.\n\nRegards,\n\nAlice" ["Spreadsheet.xls"] False
+#+END_SRC
+
+The last parameter controls the verbosity of the exchange: If set to =True=, sent and received messages will be output to the
+=stdout= stream:
+
+#+BEGIN_SRC haskell
+>>> :set -XOverloadedStrings
+>>> :module Network.Mail.Mime Network.Mail.Client.Gmail
+>>> sendGmail "alice" "password" (Address (Just "Alice") "alice@gmail.com") [Address (Just "Bob") "bob@example.com"] [] [] "Excel Spreadsheet" "Hi Bob,\n\nThe Excel spreadsheet is attached.\n\nRegards,\n\nAlice" ["Spreadsheet.xls"] True
+> EHLO
+< 220 mx.google.com ESMTP ka3sm3962295wjc.3 - gsmtp
+< 250-mx.google.com at your service, [81.50.146.29]
+< 250-SIZE 35882577
+< 250-8BITMIME
+< 250-STARTTLS
+< 250-ENHANCEDSTATUSCODES
+< 250-PIPELINING
+< 250-CHUNKING
+< 250 SMTPUTF8
+> STARTTLS
+< 220 2.0.0 Ready to start TLS
+> "EHLO"
+< 250-mx.google.com at your service, [81.50.146.29]
+< 250-SIZE 35882577
+< 250-8BITMIME
+< 250-AUTH LOGIN PLAIN XOAUTH XOAUTH2 PLAIN-CLIENTTOKEN
+< 250-ENHANCEDSTATUSCODES
+< 250-CHUNKING
+< 250 SMTPUTF8
+> "AUTH LOGIN"
+< 334 VXNlcm5hbWU6
+> "user="
+< 334 UGFzc3dvcmQ6
+> "password"
+< 235 2.7.0 Accepted
+> "MAIL FROM: <alice@gmail.com>"
+< 250 2.1.0 OK ka3sm3962295wjc.3 - gsmtp
+> "RCPT TO: <bob@example.com>"
+< 250 2.1.5 OK ka3sm3962295wjc.3 - gsmtp
+> "DATA"
+< 354  Go ahead ka3sm3962295wjc.3 - gsmtp
+> ...
+< 250 2.0.0 OK 1412242155 ka3sm3962295wjc.3 - gsmtp
+> "QUIT"
+< 221 2.0.0 closing connection ka3sm3962295wjc.3 - gsmtp
 #+END_SRC
 
 ** Resources

--- a/smtps-gmail.cabal
+++ b/smtps-gmail.cabal
@@ -21,6 +21,7 @@ Library
                     base64-bytestring,
                     bytestring,
                     cprng-aes,
+                    mtl >= 2.2,
                     data-default >= 0.5.3,
                     filepath,
                     mime-mail,


### PR DESCRIPTION
I found it useful to be able to trace what was going on, so provided this quick and (hopefully not too) dirty fix adding a flag to `sendGmail` function.
